### PR TITLE
Fix error when `grep` returns 0 rows

### DIFF
--- a/src/Technodelight/Jira/Api/GitShell/Api.php
+++ b/src/Technodelight/Jira/Api/GitShell/Api.php
@@ -32,11 +32,7 @@ class Api
 
         $converter = new XmlToArray('entry');
         $entries = $converter->asArray(implode(PHP_EOL, $this->shell->exec($command)));
-        if (empty($entries)) {
-            return [];
-        }
-
-        foreach ($entries['entry'] as $entry) {
+        if (!empty($entries['entry'])) foreach ($entries['entry'] as $entry) {
             yield LogEntry::fromArray($entry);
         }
     }

--- a/src/Technodelight/Jira/Api/GitShell/Api.php
+++ b/src/Technodelight/Jira/Api/GitShell/Api.php
@@ -32,6 +32,10 @@ class Api
 
         $converter = new XmlToArray('entry');
         $entries = $converter->asArray(implode(PHP_EOL, $this->shell->exec($command)));
+        if (empty($entries)) {
+            return [];
+        }
+
         foreach ($entries['entry'] as $entry) {
             yield LogEntry::fromArray($entry);
         }

--- a/src/Technodelight/Jira/Api/GitShell/XmlToArray.php
+++ b/src/Technodelight/Jira/Api/GitShell/XmlToArray.php
@@ -14,7 +14,7 @@ class XmlToArray
     public function asArray($string)
     {
         $array = $this->xmlAsArray($this->stringAsXml($string));
-        if ($array[$this->nodeToForceArray] != array_values($array[$this->nodeToForceArray])) {
+        if (isset($array[$this->nodeToForceArray]) && $array[$this->nodeToForceArray] != array_values($array[$this->nodeToForceArray])) {
             $array[$this->nodeToForceArray] = [$array[$this->nodeToForceArray]];
         }
         return $array;

--- a/src/Technodelight/Jira/Api/Shell/NativeShell.php
+++ b/src/Technodelight/Jira/Api/Shell/NativeShell.php
@@ -17,7 +17,7 @@ class NativeShell implements Shell
             $command->withExec($this->executable);
         }
         exec((string) $command, $result, $returnVar);
-        $result = array_filter(array_map('trim', $result));
+        $result = (array) array_filter(array_map('trim', (array) $result));
         if (!empty($returnVar)) {
             throw new ShellCommandException(
                 sprintf(

--- a/src/Technodelight/Jira/Api/Shell/NativeShell.php
+++ b/src/Technodelight/Jira/Api/Shell/NativeShell.php
@@ -17,15 +17,19 @@ class NativeShell implements Shell
             $command->withExec($this->executable);
         }
         exec((string) $command, $result, $returnVar);
+        $result = array_filter(array_map('trim', $result));
         if (!empty($returnVar)) {
-            throw new \RuntimeException(
+            throw new ShellCommandException(
                 sprintf(
                     'Error code %d during running "%s"',
                     $returnVar,
                     $command
-                )
+                ),
+                $returnVar,
+                null,
+                $result
             );
         }
-        return array_filter(array_map('trim', $result));
+        return $result;
     }
 }

--- a/src/Technodelight/Jira/Api/Shell/Shell.php
+++ b/src/Technodelight/Jira/Api/Shell/Shell.php
@@ -4,5 +4,10 @@ namespace Technodelight\Jira\Api\Shell;
 
 interface Shell
 {
+    /**
+     * @param \Technodelight\Jira\Api\Shell\Command $command
+     * @return array
+     * @throws \RuntimeException
+     */
     public function exec(Command $command);
 }

--- a/src/Technodelight/Jira/Api/Shell/ShellCommandException.php
+++ b/src/Technodelight/Jira/Api/Shell/ShellCommandException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Technodelight\Jira\Api\Shell;
+
+use RuntimeException;
+use Throwable;
+
+class ShellCommandException extends RuntimeException
+{
+    private $result;
+
+    public function __construct($message = "", $code = 0, Throwable $previous = null, array $result = [])
+    {
+        parent::__construct($message, $code, $previous);
+        $this->result = $result;
+    }
+
+    public function getResult()
+    {
+        return $this->result;
+    }
+}


### PR DESCRIPTION
- when listing branches with `git -a` and grepping for pattern `grep`
  may return code `1` thus failing the exec command which is undesired.