### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ name: Build and Create Release
 jobs:
   # This workflow contains a single job called "build"
   build:
+    permissions:
+      contents: read
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -41,6 +43,8 @@ jobs:
 
   create-release:
     name: Create Release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/technodelight/jira/security/code-scanning/1](https://github.com/technodelight/jira/security/code-scanning/1)

Add explicit `permissions` at the **job level** in `.github/workflows/publish.yml` so each job gets only what it needs:

- `build` job: only needs to checkout code and upload artifact, so set:
  - `contents: read`
- `create-release` job: creates release and uploads asset, so set:
  - `contents: write`

This preserves existing behavior while enforcing least privilege and satisfying CodeQL. No imports/dependencies are needed since this is YAML workflow configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
